### PR TITLE
Implement store filter personalization

### DIFF
--- a/HappyRapidCart/HappyRapidCart.xcodeproj/project.pbxproj
+++ b/HappyRapidCart/HappyRapidCart.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0A077A20257DF42D0045B09B /* Cart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A077A1F257DF42D0045B09B /* Cart.swift */; };
+		0A1E6FCC2581EF5100BDD62E /* Supermarket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1E6FCB2581EF5100BDD62E /* Supermarket.swift */; };
 		0A7D6C13257C952C0083A407 /* CartViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7D6C12257C952B0083A407 /* CartViewController.swift */; };
 		0A7D6C18257C98490083A407 /* CartCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7D6C17257C98490083A407 /* CartCell.swift */; };
 		0A91A64F2562210400FBA013 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A91A64E2562210400FBA013 /* AppDelegate.swift */; };
@@ -47,6 +48,7 @@
 
 /* Begin PBXFileReference section */
 		0A077A1F257DF42D0045B09B /* Cart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cart.swift; sourceTree = "<group>"; };
+		0A1E6FCB2581EF5100BDD62E /* Supermarket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Supermarket.swift; sourceTree = "<group>"; };
 		0A7D6C12257C952B0083A407 /* CartViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartViewController.swift; sourceTree = "<group>"; };
 		0A7D6C17257C98490083A407 /* CartCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartCell.swift; sourceTree = "<group>"; };
 		0A91A64B2562210400FBA013 /* HappyRapidCart.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HappyRapidCart.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -146,6 +148,7 @@
 				0A91A69625622CB600FBA013 /* LoginViewController.swift */,
 				0A7D6C12257C952B0083A407 /* CartViewController.swift */,
 				0A7D6C17257C98490083A407 /* CartCell.swift */,
+				0A1E6FCB2581EF5100BDD62E /* Supermarket.swift */,
 			);
 			path = HappyRapidCart;
 			sourceTree = "<group>";
@@ -441,6 +444,7 @@
 				0A91A64F2562210400FBA013 /* AppDelegate.swift in Sources */,
 				0A7D6C13257C952C0083A407 /* CartViewController.swift in Sources */,
 				0A91A6512562210400FBA013 /* SceneDelegate.swift in Sources */,
+				0A1E6FCC2581EF5100BDD62E /* Supermarket.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HappyRapidCart/HappyRapidCart/Base.lproj/Main.storyboard
+++ b/HappyRapidCart/HappyRapidCart/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -119,9 +119,14 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <color key="separatorColor" red="0.24092093110000001" green="0.69675141569999999" blue="0.1041586474" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <searchBar key="tableHeaderView" contentMode="redraw" placeholder="Find stores selling what you need" id="962-e3-tXk">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                    <textInputTraits key="textInputTraits"/>
+                                </searchBar>
                                 <prototypes>
                                     <tableViewCell opaque="NO" clipsSubviews="YES" contentMode="scaleAspectFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="StoreCell" rowHeight="183" id="PrY-bf-KqS" customClass="StoreCell" customModule="HappyRapidCart" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="183"/>
+                                        <rect key="frame" x="0.0" y="84" width="414" height="183"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PrY-bf-KqS" id="B7h-j3-4if">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="183"/>
@@ -207,6 +212,7 @@
                     </view>
                     <navigationItem key="navigationItem" title="Stores Near You" id="ic4-5E-baf"/>
                     <connections>
+                        <outlet property="searchBar" destination="962-e3-tXk" id="Rse-DN-O7O"/>
                         <outlet property="tableView" destination="f3Q-Hn-o8T" id="MM0-E8-dBk"/>
                     </connections>
                 </viewController>

--- a/HappyRapidCart/HappyRapidCart/ShoppingGridViewController.swift
+++ b/HappyRapidCart/HappyRapidCart/ShoppingGridViewController.swift
@@ -20,7 +20,7 @@ class ShoppingGridViewController: UIViewController, UICollectionViewDelegate, UI
     
     var products = [[String:Any]]()
     //var productsToBuy = [[String:Any]]()
-    var searchBarVariable = "cereal"
+    var searchBarVariable = "pie"
     var clickedProduct: IndexPath? = nil
     
     

--- a/HappyRapidCart/HappyRapidCart/ShoppingGridViewController.swift
+++ b/HappyRapidCart/HappyRapidCart/ShoppingGridViewController.swift
@@ -273,7 +273,6 @@ class ShoppingGridViewController: UIViewController, UICollectionViewDelegate, UI
     
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
     
-    
         if (searchBar.text!.isEmpty) {
             print("search bar text is empty")
 

--- a/HappyRapidCart/HappyRapidCart/StoreCell.swift
+++ b/HappyRapidCart/HappyRapidCart/StoreCell.swift
@@ -16,6 +16,14 @@ class StoreCell: UITableViewCell {
     
     @IBOutlet weak var storeLabel: UILabel!
     
+    
+    var s: Supermarkets! {
+            didSet {
+                storeLabel.text = s.name
+                storeImage = s.image
+            }
+        }
+    
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code

--- a/HappyRapidCart/HappyRapidCart/StoreCell.swift
+++ b/HappyRapidCart/HappyRapidCart/StoreCell.swift
@@ -17,10 +17,10 @@ class StoreCell: UITableViewCell {
     @IBOutlet weak var storeLabel: UILabel!
     
     
-    var s: Supermarkets! {
+    var s: Supermarket! {
             didSet {
                 storeLabel.text = s.name
-                storeImage = s.image
+                storeImage.image = s.image
             }
         }
     

--- a/HappyRapidCart/HappyRapidCart/StroesViewController.swift
+++ b/HappyRapidCart/HappyRapidCart/StroesViewController.swift
@@ -8,16 +8,22 @@
 import UIKit
 import Foundation
 
-class StroesViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
+class StroesViewController: UIViewController, UITableViewDelegate, UITableViewDataSource{
 
     @IBOutlet weak var tableView: UITableView!
     
-    var supermarkets = [[String:Any]]()
+    var supermarkets: [Supermarket] = []
+    var searchBarVariable = "cereal"
+    
+    @IBOutlet weak var searchBar: UISearchBar!
+    
+    var filteredSuperMarkets: [Supermarket] = []
     
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.delegate = self
         tableView.dataSource = self
+        searchBar.delegate = self
 
         let headers = [
             "x-rapidapi-host": "trueway-places.p.rapidapi.com",
@@ -37,7 +43,9 @@ class StroesViewController: UIViewController, UITableViewDelegate, UITableViewDa
                  //print(httpResponse)
                  let dataDictionary = try! JSONSerialization.jsonObject(with: data, options: []) as! [String: Any]
                  //print(dataDictionary)
-                 self.supermarkets = dataDictionary["results"] as! [[String : Any]]
+                 let results = dataDictionary["results"] as! [[String : Any]]
+                self.supermarkets = results
+                self.filteredSuperMarkets = results
                 
                  self.tableView.reloadData()
 
@@ -48,32 +56,15 @@ class StroesViewController: UIViewController, UITableViewDelegate, UITableViewDa
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return supermarkets.count
+        return filteredSuperMarkets.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "StoreCell") as! StoreCell
-        let supermarket = self.supermarkets[indexPath.row]
-        let name = supermarket["name"] as! String
+        let supermarket = self.filteredSuperMarkets[indexPath.row]
         
-        cell.storeLabel.text = name
         
-        let size = CGSize(width: 148, height: 100)
-        let scaledImage = UIImage(named: "store")?.af_imageScaled(to: size)
-        
-        cell.storeImage.image = scaledImage
-        
-        // check for store names
-        let storeNames = ["Walmart", "ALDI", "Publix", "Whole Foods", "Family Dollar", "Jumbo", "Garden Marketplace", "Mi Gente", "Oriental Market", "Oriental Supermarket"]
-        for store in storeNames{
-            if name.contains(store) {
-                cell.storeImage.image = UIImage(named: store)?.af_imageScaled(to: size)
-            }
-        }
-        
-        // configure cell shape
-        cell.storeView.layer.cornerRadius = 8
-        cell.storeImage.layer.cornerRadius = 8
+        cell.s = supermarket
         
         
         return cell
@@ -82,6 +73,7 @@ class StroesViewController: UIViewController, UITableViewDelegate, UITableViewDa
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
             return 120
     }
+  
     
     /*
     // MARK: - Navigation
@@ -93,4 +85,32 @@ class StroesViewController: UIViewController, UITableViewDelegate, UITableViewDa
     }
     */
 
+}
+
+extension StroesViewController: UISearchBarDelegate {
+
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        if searchText != "" {
+            filteredSuperMarkets = supermarkets.filter{(s: Supermarket) -> Bool in
+                return s.name.lowercased().contains(searchText.lowercased())
+            }
+        }
+        else {
+            filteredSuperMarkets = supermarkets
+        }
+        tableView.reloadData()
+    }
+
+    func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
+        self.searchBar.showsCancelButton = true
+    }
+
+    // when search bar cancel button is clicked
+    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.showsCancelButton = false
+        searchBar.text = ""
+        searchBar.resignFirstResponder() //remove keyboard
+        filteredSuperMarkets = supermarkets
+        tableView.reloadData()
+    }
 }

--- a/HappyRapidCart/HappyRapidCart/StroesViewController.swift
+++ b/HappyRapidCart/HappyRapidCart/StroesViewController.swift
@@ -44,8 +44,17 @@ class StroesViewController: UIViewController, UITableViewDelegate, UITableViewDa
                  let dataDictionary = try! JSONSerialization.jsonObject(with: data, options: []) as! [String: Any]
                  //print(dataDictionary)
                  let results = dataDictionary["results"] as! [[String : Any]]
-                self.supermarkets = results
-                self.filteredSuperMarkets = results
+                
+                var supes: [Supermarket] = []
+
+                for dictionary in results {
+                    let superM = Supermarket.init(dict: dictionary)
+                    supes.append(superM)
+                }
+                
+                
+                self.supermarkets = supes
+                self.filteredSuperMarkets = supes
                 
                  self.tableView.reloadData()
 
@@ -92,7 +101,10 @@ extension StroesViewController: UISearchBarDelegate {
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         if searchText != "" {
             filteredSuperMarkets = supermarkets.filter{(s: Supermarket) -> Bool in
-                return s.name.lowercased().contains(searchText.lowercased())
+                //do any of the words in this array exist in this string
+                let arr = ["Whole Foods Market", "ALDI"]
+                return arr.contains(where: s.name.contains)
+                //return s.name.lowercased().contains(searchText.lowercased())
             }
         }
         else {

--- a/HappyRapidCart/HappyRapidCart/Supermarket.swift
+++ b/HappyRapidCart/HappyRapidCart/Supermarket.swift
@@ -1,0 +1,39 @@
+//
+//  Supermarkets.swift
+//  HappyRapidCart
+//
+//  Created by Jasmine Omeke on 12/9/20.
+//
+
+import Foundation
+import AlamofireImage
+
+class Supermarket {
+    var name: String
+    var image: UIImage
+
+    init(dict: [String: Any]) {
+        name = dict["name"] as! String
+        image = Supermarket.getImage(name: name)
+
+    }
+
+    
+    //Helper function to get the first category from the restaurant
+    static func getImage(name: String) -> UIImage{
+            let size = CGSize(width: 148, height: 100)
+            let scaledImage = UIImage(named: "store")?.af_imageScaled(to: size)
+            
+            var finalImage = scaledImage
+            
+            // check for store names
+            let storeNames = ["Walmart", "ALDI", "Publix", "Whole Foods", "Family Dollar", "Jumbo", "Garden Marketplace", "Mi Gente", "Oriental Market", "Oriental Supermarket"]
+            for store in storeNames{
+                if name.contains(store) {
+                    finalImage = UIImage(named: store)?.af_imageScaled(to: size)
+                }
+            }
+        return finalImage!
+        }
+    
+}


### PR DESCRIPTION
This PR gives the user the ability to search for an item and then filter to which stores have that item.

This is hardcoded to always Whole Foods or ALDI and mostly is here for the effect

[1] First state: new search bar prompting the user to find stores that sell what they need
![Screen Shot 2020-12-10 at 12 08 27 AM](https://user-images.githubusercontent.com/10506008/101728479-16ee3e00-3a7c-11eb-877f-d2906cf0e59f.png)



[2] Second state: Filtered view of stores after search completes
![Screen Shot 2020-12-10 at 12 09 14 AM](https://user-images.githubusercontent.com/10506008/101728493-1b1a5b80-3a7c-11eb-9400-bb4eb639917a.png)


